### PR TITLE
Acrescentar estado de publicação nas listagens de periódicos para download (tk29)

### DIFF
--- a/application/views/pages/journals-csv.php
+++ b/application/views/pages/journals-csv.php
@@ -3,7 +3,7 @@ $now = gmdate("D-d-M-Y-H:i:s");
 header("Content-Type: application/octet-stream");
 header("Content-Disposition: attachment; filename=journals-{$now}.csv");
 ?>
-<?= lang('journals') . ", scielo_url, " . strtolower(lang('publisher'))."\n" ?>
+<?= lang('journals') . ", scielo_url, " . strtolower(lang('publisher')) . ", status\n" ?>
 <?php foreach ($journals as $journal) : ?>
-<?= $journal->title ?>, <?= $journal->scielo_url ?>, <?= $journal->publisher_name . "\n" ?>
+<?= '"' . $journal->title . '", "' . $journal->scielo_url . '", "' . $journal->publisher_name . '", "' . $journal->status . "\"\n" ?>
 <?php endforeach; ?>


### PR DESCRIPTION
Prezado(s),
Foi realizada a inclusão da propriedade 'status' dos periódicos no arquivo de download (csv).

Fix #29 

Atenciosamente,
Juliano.

![2018-10-17-211455_1920x1080_scrot](https://user-images.githubusercontent.com/377939/47123515-c1c69100-d251-11e8-9ef3-e32bbbc60355.png)
