### PR TITLE
correcao link de arquivos de todos os idiomas #tk72

### DIFF
--- a/application/views/pages/menu.php
+++ b/application/views/pages/menu.php
@@ -61,14 +61,22 @@ defined('BASEPATH') or exit('No direct script access allowed');
 
 					// Verify if the page is of the type 'pageModel-linkExternal.php' or 'pageModel-linkToDocument.php'
 					if ($subpage['template'] == 'pageModel-linkExternal.php') {
-						$link = $subpage['acf']['link_pt'];
+					
+						$language == SCIELO_LANG;
+						$link = $subpage['acf']['link_'.$language];
+					
 					} else if ($subpage['template'] == 'pageModel-linkToDocument.php') {
-						$link = $subpage['acf']['document_pt'];
+						
+						$language == SCIELO_LANG;
+						$link = $subpage['acf']['document_'.$language];
+						
+
 					} else {
 						// If the language is Portuguese it is necessary to concatenate the cookie language value. 
 						$scielo_url = ($language == SCIELO_LANG) ? base_url($language . '/') : base_url();
 						$link = str_replace(WORDPRESS_URL, $scielo_url, $subpage['link']);
 					}
+
 				?>
 				<li>
 					<a href="<?= $link ?>">


### PR DESCRIPTION
Ajuste de link de arquivos anexados.
Os links dos arquivos, independente do idioma, estavam sempre linkando para o idioma pt.
O ajuste realizado, corrige o problema utilizando o idioma atual para incluir no link do arquivo.
Foi alterado o arquivo views/pages/menu.php da linha 62 a 78
#72 