### PR TITLE
link para documento abrir em uma nova janela

### DIFF
--- a/application/views/pages/menu.php
+++ b/application/views/pages/menu.php
@@ -77,7 +77,11 @@ defined('BASEPATH') or exit('No direct script access allowed');
 
 				?>
 				<li>
-					<a href="<?= $link ?>">
+					<?php if ($subpage['template'] == 'pageModel-linkToDocument.php') { ?>
+						<a href="<?= $link ?>" target="_blank">
+					<?php }else{ ?>
+						<a href="<?= $link ?>">					
+					<?php } ?>
 						<?= $link_text ?>
 					</a>
 				</li>


### PR DESCRIPTION
Foi incluída uma verificação de tipo de template.
Quando é um tipo de template de arquivo, ele deve abrir em uma nova janela.
Neste caso, foi adicionado o atributo target="_blank"
#83 