### PR TITLE
link da declaracao de acesso aberto aponta sempre para vs pt-br

### DIFF
--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -43,6 +43,7 @@ class Home extends CI_Controller
 		$this->set_language();
 		$this->load_static_texts_by_language();
 		$this->load_about_link(); // The about link is the same in any page, so I load it here in the constructor.			
+		$this->load_openaccessdeclaration_link(); // The open access link in footer section, so I load it here in the constructor.			
 		$this->load_footer(); // The footer is the same in any page, so I load it here in the constructor.	
 	}
 
@@ -549,6 +550,25 @@ class Home extends CI_Controller
 
 		$about_menu_item = array('link' => base_url($this->language . '/' . $about_url), 'text' => $about['title']['rendered']);
 		$this->load->vars('about_menu_item', $about_menu_item);
+	}
+
+	/**
+	 * Get the Open Access Page link and text for Home controller.
+	 *
+	 * @return void
+	 */
+	private function load_openaccessdeclaration_link()
+	{
+
+		// Load the about page content from the json array
+		$oad = $this->get_content_from_cache('open-acess-link', FOUR_HOURS_TIMEOUT, OPENACCESS_EN_API_PATH, OPENACCESS_ES_API_PATH, OPENACCESS_API_PATH);
+
+		$oad_url = explode('/', $oad['link']);
+
+		$oad_url = $oad_url[count($oad_url) - 2];
+
+		$oad_menu_item = array('link' => $oad_url, 'text' => $oad['title']['rendered']);
+		$this->load->vars('oad_menu_item', $oad_menu_item);
 	}
 
 	/**

--- a/application/views/partials/footer.php
+++ b/application/views/partials/footer.php
@@ -20,7 +20,7 @@ defined('BASEPATH') or exit('No direct script access allowed');
         <?php endforeach; ?>
     </div>
     <div class="container collectionLicense">
-        <a href="<?= $about_menu_item['link'] ?>/declaracao-de-acesso-aberto" class="ico-oa">
+        <a href="<?= $about_menu_item['link'] ?>/<?= $oad_menu_item['link'] ?>" class="ico-oa">
             <?= $this->Footer->get_open_access_declaration() ?>
         </a>
     </div>


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona links dinamicos para as variações de idiomas do link da declaração de acesso aberto que aparece no footer do sistema inteiro.

#### Onde a revisão poderia começar?
Application/controllers/home.php
Application/views/partials/footer.php

#### Como este poderia ser testado manualmente?
1 - Insira os codigos enviados no sistema
2 - limpe o cache da aplicação acessando a url:
scielo.org/cache_util/clean_cache 
onde scielo.org é onde está hospedada a aplicação
3 - mude o idioma da aplicação para algum que seja diferente de pt-br
4- verifique no footer, se o link para a declaração de acesso aberto direciona para o respectivo idioma

#### Algum cenário de contexto que queira dar?
Existe uma versão de declaração de acesso aberto para cada idioma.

### Screenshots
não se aplica.

#### Quais são tickets relevantes?
#94 

### Referências
--


