### PR TITLE
Habilita método para atualizar o banco de dados

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,5 +3,6 @@ RewriteEngine on
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond $1 !^(index\.php|images|css|javascript|rte|robots\.txt)
+RewriteCond $1 !cache_util
 RewriteRule ^(.*)$ index.php?$1 [L,QSA]
 </IfModule>

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -223,7 +223,7 @@ $config['allow_get_array'] = TRUE;
 | your log files will fill up very fast.
 |
 */
-$config['log_threshold'] = 0;
+$config['log_threshold'] = 1;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Cache_util.php
+++ b/application/controllers/Cache_util.php
@@ -24,6 +24,30 @@ class Cache_util extends CI_Controller
 {
 
 	/**
+	 * Update cache database. This function is only acessible by
+	 * command line, to run this method execute:
+	 * `php index.php cache_util update_database`
+	 */
+	public function update_database()
+	{
+		if (!defined("STDIN") && php_sapi_name() != "cli") {
+			exit("Not allowed");
+		}
+
+		log_message("debug", "Running cache update tool, it may take some minutes, please wait.");
+
+		try {
+			$this->clean_database_cache();
+			log_message("debug", "Update finished comfortably.");
+		} catch (Exception $e) {
+			log_message("error", "Something went wrong, please verify traceback.");
+			log_message("error", var_dump($e));
+		}
+
+		exit(0);
+	}
+
+	/**
 	 * Check if the database timeout is over, clear the cache and redirect to home.
 	 * Note that if the timeout for the database clean up is over, it is necessary
 	 * to make the requests and process the data to normalize it.
@@ -52,7 +76,7 @@ class Cache_util extends CI_Controller
 			$date2 = new DateTime();
 
 			$diff = $date2->diff($date1); // Get DateInterval Object
-			
+
 			// Verify if it pass than 30 days since the last processing.
 			if ($diff->format('%d') > 30) {
 


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request adiciona um método ao controller `Cache_util` para facilitar a atualização do banco de dados utilizado como cache da aplicação. O novo método é acessível apenas via linha de comando e não deve em hipótese alguma permitir a sua execução por meio de uma URL pública.

Foi utilizado um método já existente no projeto (`clean_database_cache`), ele é de fato o responsável por realizar a exclusão dos dados antigos e inserção dos novos dados advindos do `article meta`.

#### Onde a revisão poderia começar?
- `application/controllers/Cache_util.php` linha `31`

#### Como este poderia ser testado manualmente?
Para realizar o teste manual deste pr, deve-se:
- Iniciar uma instância do `scielo.org`;
- Realizar uma query sql ao banco de cache ex: `select count(id_journal) from journals;`
- Verificar a quantidade de itens;
- Executar a atualização do banco via linha de comando `docker-compose exec webapp php index.php cache_util update_dabatase`;
- Reexecutar a query sql para conferir a quantidade de itens;

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
Quantidade de artigos antes da atualização:
<img width="230" alt="Screen Shot 2019-05-08 at 11 11 25" src="https://user-images.githubusercontent.com/4604104/57381803-0b40e400-7182-11e9-899f-2a62e33946ed.png">

#### Quais são tickets relevantes?
#77 

### Referências
N/A
