### PR TITLE
Link download na pagina de bibliografia e ajuste da referencia

### DIFF
--- a/application/views/pages/bibliography.php
+++ b/application/views/pages/bibliography.php
@@ -67,7 +67,10 @@ defined('BASEPATH') or exit('No direct script access allowed');
                 }
                 ?>
                 <li class="<?= $icon ?>">
-                    <?= $bibliography['reference'] ?> <a href="<?= $bibliography['available_from'] ?>"><?= $bibliography['available_from'] ?></a>
+                    <?= $bibliography['reference'] ?>
+                    <?php if (!empty($bibliography['link_download_'.$language])) : ?> 
+                    | <a href="<?= $bibliography['link_download_'.$language] ?>" target="_blank"><span class="ico-download"></span> Download</a>
+                    <?php endif; ?>    
                 </li>
                 <?php endforeach; ?>
             </ul>

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -1694,8 +1694,21 @@ section{
 					background-repeat:no-repeat;
 					background-position: 1.6rem center;
 				}
+
+				p{
+					display: inline;
+				}
 			}
 		}
+	}
+
+	.ico-download{
+		display: inline-block;
+		position: relative;
+		top: 2px;
+		width:16px;
+		height:16px;
+		background-image: svg-uri('<svg height="16px" version="1.1" viewBox="0 0 16 16" width="16px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><title/><defs/><g fill="none" fill-rule="evenodd" id="Icons with numbers" stroke="none" stroke-width="1"><g fill="#337ab7" id="Group" transform="translate(-720.000000, -432.000000)"><path d="M721,446 L733,446 L733,443 L735,443 L735,446 L735,448 L721,448 Z M721,443 L723,443 L723,446 L721,446 Z M726,433 L730,433 L730,440 L732,440 L728,445 L724,440 L726,440 Z M726,433" id="Rectangle 217"/></g></g></svg>');
 	}
 
 	.list-ebook{


### PR DESCRIPTION
#### O que esse PR faz?
(#88 )Inclui a opção de link de download da referencia contida na página de referencia.
Este pull request apenas mexe na interface, sendo que o link deve ser inserido pelo painel administrativo, nos campos:
link_download_pt
link_download_en
link_donwload_es

(#105)Além disso este pull-request ajusta o texto da referência de maneira que traga o link como continuação da referência e não como um campo auxiliar.

Tomei a liberdade de incluir os dois ajustes no mesmo pull request após conversa com o @alexxxmendonca e por serem ajustes pequenos e de simples entendimento ao analisar o código.

#### Onde a revisão poderia começar?
Primeiro é importante limpar o cache da aplicação.
Aqui localmente, eu rodo a seguinte url:
http://localhost/cache_util/clean_cache

Em seguida, acesse as páginas (link no canto superior direito):
Sobre o SciELO > SciELO > Bibliografia SciELO.

Nessa página estarão os itens do tipo link, que aparecem com um ícone de elo de corrente a frente.
Perceba que o link deve estar na mesma linha que o restante da referencia. Observe abaixo o screenshot.
Observe também que está visível um link para o download do material em questão. Observe também no screenshot.

#### Como este poderia ser testado manualmente?
Apenas siga os passos acima.

#### Algum cenário de contexto que queira dar?
Muito importante limpar o cache da aplicação e que o @alexxxmendonca já tenha inserido os devidos links para download de cada referência.

### Screenshots
![Screen Shot 2019-06-05 at 5 44 44 PM](https://user-images.githubusercontent.com/22373640/58989142-af39a180-87b9-11e9-8028-4a7a05779e5e.png)


#### Quais são tickets relevantes?
#88 e #105

### Referências
Muita conversa com o @alexxxmendonca para entendimento e resolução do problema.


