### PR TITLE
Remoção da obrigatoriedade dos campos link e texto do link do alerta 

### DIFF
--- a/application/models/Alert.php
+++ b/application/models/Alert.php
@@ -249,7 +249,13 @@ class Alert
                 // Get the link's content and anchor.
 				$this->link  = $this->alert_json['acf']['link'];
 				$this->link_text  = $this->alert_json['acf']['linkText'];
-				$this->outside_column_size_desktop = "col-xs-12 col-sm-11 col-md-9";
+				
+				if($this->link){
+					$this->outside_column_size_desktop = "col-xs-12 col-sm-11 col-md-9";
+				}else{
+					$this->outside_column_size_desktop = "col-xs-12 col-sm-12 col-md-12";
+				}
+				
             }
 			
         }

--- a/application/views/partials/alert.php
+++ b/application/views/partials/alert.php
@@ -16,7 +16,8 @@ defined('BASEPATH') OR exit('No direct script access allowed');
                 </div>
             </div>       
 
-        <?php if($this->Alert->is_link_visible()):?>
+
+        <?php if($this->Alert->get_link()):?>
             <div class="col-xs-12 col-sm-1 col-md-3">
                 <div class="cta-notification">
                     <a href="<?= $this->Alert->get_link() ?>" class="btn btn-arrow arrow-white"><?= $this->Alert->get_link_text() ?></a>

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -88,17 +88,10 @@ body{
 
 		.cta-notification{
 			text-align:center;
-			//background: green;
-			//margin-top:-30px;
-
-			@media (min-width: $screen-sm-min) {
-    			//text-align:right;
-    			//margin-right: 1.6rem;
-  			}
 
   			.btn-arrow{
-				//margin-top: 1.4rem;
 				border:1px solid white;
+				min-height: 29px;
 
 				@media (max-width: $screen-sm-max) {
 					padding-right:12px;


### PR DESCRIPTION
#### O que esse PR faz?
Trata a interface no caso de não haver link e / ou texto do link preenchidos no cadastro de alerta no topo

#### Onde a revisão poderia começar?
Acesse o painel administrativo (wordpress) e inclua um alerta sem o link e sem o texto de link.
A interface deve se comportar de uma maneira que ocupe toda a largura da tela, ocupando as 12 colunas do bootstrap.
Caso exista link e não exista texto do link, o botão de acesso ao link ficará visível sem label algum, apenas exibindo uma seta.
Caso o link não exista mas o texto do link exista, o botão não é exibido.
Vale lembrar que para verificar corretamente o ajuste é importante limpar o cache da aplicação.
Aqui localmente, eu executo o comando:
http://localhost/cache_util/clean_cache
Para que o comando acima funcione, verifique o arquivo .htaccess na raiz do sistema. Remova a linha que cita o "cache_util".

#### Como este poderia ser testado manualmente?
Siga os passos descritos acima.

#### Algum cenário de contexto que queira dar?
Sempre limpe o cache da aplicação para testar qualquer mudança de exibição de conteúdo.

### Screenshots
![Screen Shot 2019-06-06 at 2 23 12 PM](https://user-images.githubusercontent.com/22373640/59052982-b10d6e80-8866-11e9-85b7-53a2d44479e4.png)
![Screen Shot 2019-06-06 at 2 21 59 PM](https://user-images.githubusercontent.com/22373640/59052983-b1a60500-8866-11e9-8fc9-0b6160c3d244.png)
![Screen Shot 2019-06-06 at 2 18 33 PM](https://user-images.githubusercontent.com/22373640/59052984-b23e9b80-8866-11e9-9c6b-fa39a280c6a8.png)


#### Quais são tickets relevantes?
#89 

### Referências
--


