### PR TITLE
Adiciona crontab ao nível do container, remove bloqueio de urls relacionadas ao cache e atualiza banco de cache durante build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,10 @@ user_guide_src/cilexer/pycilexer.egg-info/*
 node_modules/
 
 # CSS Files
-static/style.css
-static/style.css.map
+static/css/style.css
+static/css/style.css.map
+static/css/journal-print.css
+static/css/journal-print.css.map
 
 # JavaScript
 static/js/scielo-min.js

--- a/.htaccess
+++ b/.htaccess
@@ -3,6 +3,5 @@ RewriteEngine on
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond $1 !^(index\.php|images|css|javascript|rte|robots\.txt)
-RewriteCond $1 !cache_util
 RewriteRule ^(.*)$ index.php?$1 [L,QSA]
 </IfModule>

--- a/docker/application-cron
+++ b/docker/application-cron
@@ -1,0 +1,2 @@
+*/60 * * * * echo Cleaning application cache > /proc/1/fd/1 && php /var/www/site/index.php cache_util clean_cache >&1
+0 3 * * 1,5 echo Updating application database > /proc/1/fd/1 && php /var/www/site/index.php cache_util update_database >&1

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -154,3 +154,7 @@ startretries=10
 ;autorestart=true
 ;priority=300
 
+[program:cron]
+command = cron -f
+autostart=true
+autorestart=true


### PR DESCRIPTION
#### O que esse PR faz?
- Corrige problemas relacionados a limpeza de cache e atualização da base sqlite.
- Remove bloqueio do `.htaccess`.
- Atualiza banco de dados durante o build da imagem.

#### Onde a revisão poderia começar?
- `/Dockerfile` L: `38`

#### Como este poderia ser testado manualmente?
Para testar esse PR manualmente deve-se:

1. Primeiro caso de teste
- Fazer o build desta branch;
- Rodar um container com a imagem gerada anteriormente;
- Observar `uma hora depois` (se você não alterou o `cron`) que a aplicação teve o seu cache limpo (pode ser visto no log do docker).

2. Segundo caso de teste
- Deve ser possível limpar o cache acessando a url `/cache_util/clean_cache`;

3. Terceiro caso de teste
- Ao realizar o build da imagem deve-se ter a base de dados atualizada;
- Acesse a listagem de periódicos;
- Busque por periódicos desta lista (https://gist.github.com/joffilyfe/b54c0128dcb71086f4670e78f59e95a9);
- Os periódicos devem estar disponíveis.
#### Algum cenário de contexto que queira dar?

N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A

