### PR TITLE
Exibição da data de atualização do post no lugar da data de publicação

### DIFF
--- a/application/views/pages/accordion.php
+++ b/application/views/pages/accordion.php
@@ -46,7 +46,7 @@ defined('BASEPATH') or exit('No direct script access allowed');
     <div class="container">
 
 		<div class="page-updated-at">
-			<?php $date = new DateTime($page['date']);?>
+			<?php $date = new DateTime($page['modified']);?>
 			<?= "(" . lang('updated') . ": " . $date->format('d/m/Y') . ")" ?>
 		</div>
 

--- a/application/views/pages/bibliography.php
+++ b/application/views/pages/bibliography.php
@@ -45,7 +45,7 @@ defined('BASEPATH') or exit('No direct script access allowed');
 <section class="collection collectionAbout">
     <div class="container">
         <div class="page-updated-at">
-            <?php $date = new DateTime($page['date']);?>
+            <?php $date = new DateTime($page['modified']);?>
             <?= "(" . lang('updated') . ": " . $date->format('d/m/Y') . ")" ?>
         </div>
         <?php if (!empty($page['content']['rendered'])) : ?>

--- a/application/views/pages/booklist.php
+++ b/application/views/pages/booklist.php
@@ -45,7 +45,7 @@ defined('BASEPATH') or exit('No direct script access allowed');
 <section>
     <div class="container">
         <div class="page-updated-at">
-            <?php $date = new DateTime($page['date']);?>
+            <?php $date = new DateTime($page['modified']);?>
             <?= "(" . lang('updated') . ": " . $date->format('d/m/Y') . ")" ?>
         </div>
         <?php if (!empty($page['content']['rendered'])) : ?>

--- a/application/views/pages/content.php
+++ b/application/views/pages/content.php
@@ -48,7 +48,7 @@ defined('BASEPATH') or exit('No direct script access allowed');
 			<div class="col-xs-12 content">
 				
 				<div class="page-updated-at">
-					<?php $date = new DateTime($page['date']);?>
+					<?php $date = new DateTime($page['modified']);?>
 					<?= "(" . lang('updated') . ": " . $date->format('d/m/Y') . ")" ?>
 				</div>
 


### PR DESCRIPTION
#### O que esse PR faz?
Troca a variável que é exibida como data de publicação.
Conforme solicitado, agora está exibindo a data da última atualização do post.

#### Onde a revisão poderia começar?
No painel administrativo do wordpress, acesse um post de conteúdo dos tipos:
- accordion
- bibliography
- booklist
- content

No painel verifique a data da última atualização do post.

Depois, para comparar, abra em uma nova aba o post em questão.
A data exibida deve bater com a data da última modificação e não com a data de publicação.

#### Como este poderia ser testado manualmente?
Siga os passos citados acima.

#### Algum cenário de contexto que queira dar?
Talvez seja necessário limpar o cache da aplicação.

### Screenshots
Verifique a data que aparece no canto superior direito do conteúdo:
<img width="1197" alt="Screen Shot 2019-07-04 at 11 54 57 AM" src="https://user-images.githubusercontent.com/22373640/60675382-a8eb2380-9e52-11e9-9c81-6590c3a71127.png">

Agora verifique a data da última revisão feita na postagem.
<img width="1020" alt="Screen Shot 2019-07-04 at 11 55 20 AM" src="https://user-images.githubusercontent.com/22373640/60675396-aee10480-9e52-11e9-8037-31a522a909f0.png">

As duas datas devem ser iguais.

#### Quais são tickets relevantes?
#97 

### Referências
--


