### PR TITLE
Inclusão do botão submit ao formulário de busca por periódicos

### DIFF
--- a/application/views/partials/journals.php
+++ b/application/views/partials/journals.php
@@ -19,6 +19,7 @@ defined('BASEPATH') or exit('No direct script access allowed');
                                 <li><a href="javascript:scieloLib.SetMatching('<?=lang('extact_title')?>', 'extact_title');"><?=lang('extact_title')?></a></li>
                                 <li><a href="javascript:scieloLib.SetMatching('<?=lang('starts_with')?>', 'starts_with');"><?=lang('starts_with')?></a></li>
                             </ul>
+                            <input type="submit" class="btn btn-primary" value="" alt="Buscar" title="Buscar">
                         </div><!-- /input-group-btn -->
                     </div><!-- /input-group -->
                 

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -733,6 +733,15 @@ section{
 					.btn-default{
 						border-color: #DAE3F4;
 					}
+
+					input[type="submit"] {
+						&.btn-primary{
+							background-image: svg-uri('<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15 15"><defs><style>.cls-1{fill:#fff;fill-rule:evenodd;}</style></defs><title>magnifier-white</title><path id="path-1" class="cls-1" d="M1.06,5.73A4.67,4.67,0,1,1,5.73,10.4,4.67,4.67,0,0,1,1.06,5.73m13.63,7L12,10a1,1,0,0,0-1.25-.18l-.51-.52A5.73,5.73,0,1,0,0,5.73a5.72,5.72,0,0,0,9.28,4.5l.52.51A1,1,0,0,0,10,12l2.7,2.7a1.07,1.07,0,0,0,1.5,0l.51-.51a1.07,1.07,0,0,0,0-1.5"/></svg>');
+							background-size: 15px 15px;
+							background-position:center center;
+							background-repeat:no-repeat;
+						}
+					}
 				}
 
 


### PR DESCRIPTION
#### O que esse PR faz?
inclui um botão de submit no formulário de busca por periódicos na home do org.

#### Onde a revisão poderia começar?
Acesse a home e verifique a aba periódicos. Deve ser possível visualizar um botão azul com uma lupa branca ao lado do componente select.

#### Como este poderia ser testado manualmente?
Execute os passos descritos anteriormente.

#### Algum cenário de contexto que queira dar?
--

### Screenshots
![Screen Shot 2019-07-10 at 11 44 00 AM](https://user-images.githubusercontent.com/22373640/60997832-24a30f80-a32e-11e9-9f32-8ca878e9bf25.png)


#### Quais são tickets relevantes?
#110 

### Referências
https://uxplanet.org/design-a-perfect-search-box-b6baaf9599c


