### PR TITLE
Inclusão do termo "todos os assuntos" no arquivo de idiomas bt-br

### DIFF
--- a/application/language/portuguese-brazilian/scielo_lang.php
+++ b/application/language/portuguese-brazilian/scielo_lang.php
@@ -48,6 +48,7 @@ $lang['list_journals_by_alphabetical_order'] = 'Por ordem alfabética';
 $lang['by_publisher'] = 'Por publicador';
 $lang['publisher_list'] = 'Por publicadores';
 $lang['by_subject'] = 'Por assunto';
+$lang['all_subjects'] = 'Todos os assuntos';
 $lang['all'] = 'Todos';
 $lang['active_journals'] = 'Periódicos ativos';
 $lang['actives'] = 'Ativos';


### PR DESCRIPTION
#### O que esse PR faz?
Inclui o termo "Todos os assuntos" ao arquivo de idiomas pt-br

#### Onde a revisão poderia começar?
Acesse a lista de periódicos, e verifique o select responsável pela seleção do assunto. Nele, deve conter a opção "Todos os assuntos". 
Antes do ajuste, este termo aparecia em inglês.

#### Como este poderia ser testado manualmente?
Siga o passo anterior

#### Algum cenário de contexto que queira dar?
Talvez seja necessário limpar o cache da aplicação.

### Screenshots
![Screen Shot 2019-07-18 at 11 34 39 AM](https://user-images.githubusercontent.com/22373640/61466313-12d5f380-a950-11e9-80f8-7f96c77939b6.png)

#### Quais são tickets relevantes?
#119 

### Referências
--


