### PR TITLE
Alteraçao dos texto de traduçao #129

### DIFF
--- a/application/language/english/scielo_lang.php
+++ b/application/language/english/scielo_lang.php
@@ -90,7 +90,7 @@ $lang['extact_title'] = 'Exact title';
 $lang['starts_with'] = 'Starts with';
 $lang['search_btn'] = 'Search';
 $lang['clean_btn'] = 'Clear';
-$lang["content_error"] = 'Sorry, this content is unavailable at the moment.';
+$lang["content_error"] = 'Sorry, this content is currently unavailable';
 $lang['with_initial_letter'] = '&nbsp;with the initial letter&nbsp;';
 $lang['page_not_found_with_details'] = '
 This page could not be found. The content you are looking for was probably moved or is no longer available.

--- a/application/language/spanish/scielo_lang.php
+++ b/application/language/spanish/scielo_lang.php
@@ -89,7 +89,7 @@ $lang['extact_title'] = 'Título exacto';
 $lang['starts_with'] = 'Comienza con';
 $lang['search_btn'] = 'Buscar';
 $lang['clean_btn'] = 'Limpiar';
-$lang["content_error"] = 'Lo sentimos, este contenido está indisponible temporalmente.';
+$lang["content_error"] = 'Lo sentimos, este contenido no está disponible en este momento';
 $lang['with_initial_letter'] = '&nbsp;con la letra inicial&nbsp;';
 $lang['page_not_found_with_details'] = '
 No se pudo encontrar esta página. El contenido que ha buscado probablemente se ha movido o no está disponible.


### PR DESCRIPTION
#### O que esse PR faz?
Esse Pr altera os textos das mensagens de erro como solicitado no comentario do TK #129  

> @cesarbruschetta na verdade.... conversando com a Amanda, ela sugeriu que o espanhol ficaria mais fluído se fosse algo como "Lo sentimos, este contenido no está disponible en este momento". E, aproveitando, o inglês não ficaria melhor se fosse "Sorry, this content is currently unavailable"?


_Originally posted by @carolinatanigushi in https://github.com/scieloorg/scielo.org/issues/129#issuecomment-514167166_

#### Onde a revisão poderia começar?
Pelos arquivos:
* `application/language/english/scielo_lang.php`
* `application/language/spanish/scielo_lang.php`

#### Como este poderia ser testado manualmente?
Apos atualizar o ambiente verifique se as mensagem aparecem como solicitado

#### Algum cenário de contexto que queira dar?
Como solicitado os texto para as mensagens de erros do tk #129 ficara:

 Lang | Text 
--|--
 PT | Desculpe, este conteúdo está temporariamente indisponível. 
 EN | Sorry, this content is currently unavailable 
 ES | Lo sentimos, este contenido no está disponible en este momento 

#### Quais são tickets relevantes?
#129 

