### PR TITLE
ajuste do icone relacionado a nova coleção West Indies

### DIFF
--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -449,10 +449,11 @@ section{
 
 			&.scielo-books,
 			&.flag-generic,
-			&.flag-spa{ // genericos X
+			&.flag-spa,
+			&.flag-wid{ // genericos X
 
 				&::before{
-					background-image: url(../images/ico/artigo.png);
+					background-image: url('../images/ico/artigo.png');
 					box-shadow:none;
 					width:50px;
 					height:50px;


### PR DESCRIPTION
#### O que esse PR faz?
Soluciona o problema do ícone em branco na nova coleção West Indies

#### Onde a revisão poderia começar?
Acesse a home do projeto, localize a aba coleções, onde aparecem as bandeiras. Alí estará localizada a nova coleção chamada "West Indies". O Seu ícone deve estar igual ao "Pesquisa FAPESP"

#### Como este poderia ser testado manualmente?
Siga o passo anterior

#### Algum cenário de contexto que queira dar?
--

### Screenshots
![Screen Shot 2019-08-01 at 2 47 45 PM](https://user-images.githubusercontent.com/22373640/62318370-11d5b380-b472-11e9-9a39-02232cb5ca42.png)


#### Quais são tickets relevantes?
#133 

### Referências
--


