### PR TITLE
Busca interna scielo.org com paginação

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 
+docker-compose-local.yml
+
 application/cache/*/Files
 !application/cache/index.html
 !application/cache/database/data.db

--- a/application/language/english/pagination_lang.php
+++ b/application/language/english/pagination_lang.php
@@ -3,14 +3,13 @@
  * System messages translation for CodeIgniter(tm)
  *
  * @author	CodeIgniter community
- * @author	Iban Eguia
  * @copyright	Copyright (c) 2014-2018, British Columbia Institute of Technology (http://bcit.ca/)
  * @license	http://opensource.org/licenses/MIT	MIT License
  * @link	https://codeigniter.com
  */
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-$lang['pagination_first_link']	= 'Primero';
-$lang['pagination_next_link']	= '&gt;';
-$lang['pagination_prev_link']	= '&lt;';
-$lang['pagination_last_link']	= 'Última';
+$lang['pagination_first_link'] = 'First';
+$lang['pagination_next_link'] = '&gt;';
+$lang['pagination_prev_link'] = '&lt;';
+$lang['pagination_last_link'] = 'Last';

--- a/application/language/english/scielo_lang.php
+++ b/application/language/english/scielo_lang.php
@@ -92,6 +92,9 @@ $lang['search_btn'] = 'Search';
 $lang['clean_btn'] = 'Clear';
 $lang["content_error"] = 'Sorry, this content is currently unavailable';
 $lang['with_initial_letter'] = '&nbsp;with the initial letter&nbsp;';
+$lang["internal_search_placeholder"] = "Criteria, guides, announcements etc";
+$lang['displaying_results_for_term'] = 'Displaying results for term ';
+$lang['no_items_found_for_term'] = 'No items found for term ';
 $lang['page_not_found_with_details'] = '
 This page could not be found. The content you are looking for was probably moved or is no longer available.
 <br><br>

--- a/application/language/portuguese-brazilian/pagination_lang.php
+++ b/application/language/portuguese-brazilian/pagination_lang.php
@@ -9,7 +9,7 @@
  */
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-$lang['pagination_first_link'] = '&lsaquo; Primeiro';
+$lang['pagination_first_link'] = 'Primeira';
 $lang['pagination_next_link'] = '&gt;';
 $lang['pagination_prev_link'] = '&lt;';
-$lang['pagination_last_link'] = 'Último &rsaquo;';
+$lang['pagination_last_link'] = 'Última';

--- a/application/language/portuguese-brazilian/scielo_lang.php
+++ b/application/language/portuguese-brazilian/scielo_lang.php
@@ -90,6 +90,9 @@ $lang['starts_with'] = 'Começa com';
 $lang['search_btn'] = 'Buscar';
 $lang['clean_btn'] = 'Limpar';
 $lang["content_error"] = 'Desculpe, este conteúdo está temporariamente indisponível.';
+$lang["internal_search_placeholder"] = "Critérios, guias, comunicados etc";
+$lang['displaying_results_for_term'] = 'Exibindo resultados para o termo ';
+$lang['no_items_found_for_term'] = 'Nenhum item encontrado para o termo ';
 $lang['page_not_found_with_details'] = '
 Não foi possível encontrar essa página. O conteúdo que você buscou provavelmente foi movido ou não está mais disponível.
 <br><br>

--- a/application/language/spanish/scielo_lang.php
+++ b/application/language/spanish/scielo_lang.php
@@ -87,10 +87,13 @@ $lang['watch_video'] = 'Ver en YouTube';
 $lang['contains'] = 'Contiene';
 $lang['extact_title'] = 'Título exacto';
 $lang['starts_with'] = 'Comienza con';
-$lang['search_btn'] = 'Buscar';
+$lang['search_btn'] = 'Búsqueda';
 $lang['clean_btn'] = 'Limpiar';
 $lang["content_error"] = 'Lo sentimos, este contenido no está disponible en este momento';
 $lang['with_initial_letter'] = '&nbsp;con la letra inicial&nbsp;';
+$lang["internal_search_placeholder"] = "Criterios, guías, anuncios, etc.";
+$lang['displaying_results_for_term'] = 'Mostrando resultados para el término ';
+$lang['no_items_found_for_term'] = 'No se encontraron elementos para el término ';
 $lang['page_not_found_with_details'] = '
 No se pudo encontrar esta página. El contenido que ha buscado probablemente se ha movido o no está disponible.
 <br><br>

--- a/application/views/pages/accordion.php
+++ b/application/views/pages/accordion.php
@@ -45,6 +45,8 @@ defined('BASEPATH') or exit('No direct script access allowed');
 <section>
     <div class="container">
 
+    	<?php $this->load->view('partials/internal-search-box'); ?>
+
 		<div class="page-updated-at">
 			<?php $date = new DateTime($page['modified']);?>
 			<?= "(" . lang('updated') . ": " . $date->format('d/m/Y') . ")" ?>

--- a/application/views/pages/bibliography.php
+++ b/application/views/pages/bibliography.php
@@ -44,6 +44,9 @@ defined('BASEPATH') or exit('No direct script access allowed');
 
 <section class="collection collectionAbout">
     <div class="container">
+
+        <?php $this->load->view('partials/internal-search-box'); ?>
+        
         <div class="page-updated-at">
             <?php $date = new DateTime($page['modified']);?>
             <?= "(" . lang('updated') . ": " . $date->format('d/m/Y') . ")" ?>

--- a/application/views/pages/booklist.php
+++ b/application/views/pages/booklist.php
@@ -44,6 +44,9 @@ defined('BASEPATH') or exit('No direct script access allowed');
 
 <section>
     <div class="container">
+
+        <?php $this->load->view('partials/internal-search-box'); ?>
+        
         <div class="page-updated-at">
             <?php $date = new DateTime($page['modified']);?>
             <?= "(" . lang('updated') . ": " . $date->format('d/m/Y') . ")" ?>

--- a/application/views/pages/content.php
+++ b/application/views/pages/content.php
@@ -46,6 +46,8 @@ defined('BASEPATH') or exit('No direct script access allowed');
     <div class="container">
 		<div class="row">
 			<div class="col-xs-12 content">
+
+				<?php $this->load->view('partials/internal-search-box'); ?>
 				
 				<div class="page-updated-at">
 					<?php $date = new DateTime($page['modified']);?>

--- a/application/views/pages/menu.php
+++ b/application/views/pages/menu.php
@@ -44,6 +44,9 @@ defined('BASEPATH') or exit('No direct script access allowed');
 
 <section class="collection collectionAbout">
 	<div class="container">
+
+		<?php $this->load->view('partials/internal-search-box'); ?>
+		
 		<?php if (!empty($page['content']['rendered'])) : ?>
 		<div class="row">
 			<div class="col-xs-12">

--- a/application/views/pages/search_results.php
+++ b/application/views/pages/search_results.php
@@ -1,0 +1,157 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+?>
+
+<!-- header -->
+<?php $this->load->view('partials/header'); ?>
+<!-- ./header -->
+
+<!-- language-menu -->
+<?php $this->load->view('partials/language-menu'); ?>
+<!-- ./language-menu -->
+
+<section>
+	<div class="breadcrumb">
+		<div class="container">
+			<div class="row">
+				<div class="breadcrumb-path">
+					<div class="breadcrumb-path">
+						<ul>
+							<li>
+								<a href="<?= base_url($language) ?>">Home</a>
+							</li>
+							<li>
+								<a href="<?= $about_menu_item['link'] ?>"><?= $about_menu_item['text'] ?></a>
+							</li>
+							<li>
+								<?= lang('search_btn') ?>
+							</li>
+						</ul>
+					</div>
+				</div>
+			</div>
+			<div class="row">
+
+				<div class="col-xs-12 col-sm-8 col-md-9">
+					<h2 class="breadTitle"><?= lang('displaying_results_for_term')."<i>".htmlspecialchars(strip_tags($query))."</i>"; ?></h2>
+				</div>
+				<div class="col-xs-12 col-sm-4 col-md-3">
+					<!-- share -->
+					<?php $this->load->view('partials/share'); ?>
+					<!-- ./share -->
+				</div>
+			</div>
+		</div>
+	</div>
+</section>
+
+<section class="collection collectionAbout">
+	<div class="container">
+		
+		<?php $this->load->view('partials/internal-search-box'); ?>
+
+		<?php if($paged_json){ ?>
+				
+			<?php for($i=0;$i<count($paged_json);$i++) { ?>
+
+				<?php
+					$link_text = $paged_json[$i]['title']['rendered'];
+
+					// Verify if the page is of the type 'attachment'
+					/*
+
+					To have the system search the contents of attachments but 
+					not show attachments directly in the results list, read and 
+					follow the steps in this article:
+					https://searchwp.com/docs/kb/post-parent-attribution/
+					
+					*/
+					 
+					if ($paged_json[$i]['type'] == 'attachment'){
+						
+						$link = $paged_json[$i]['guid']['rendered'];
+					
+					}
+
+					
+					else if($paged_json[$i]['template'] == 'pageModel-linkExternal.php'){
+
+						$link = $paged_json[$i]['acf']['link_'.$language]; 
+					
+					}else if($paged_json[$i]['template'] == 'pageModel-linkToDocument.php'){
+
+						$link = $paged_json[$i]['acf']['document_'.$language];
+
+					}
+					
+
+					else{
+
+						// If the language is Portuguese it is necessary to concatenate the cookie language value. 
+						$scielo_url = ($language == SCIELO_LANG) ? base_url($language . '/') : base_url();
+						$link = str_replace(WORDPRESS_URL, $scielo_url, $paged_json[$i]['link']);
+						
+					}
+				?>
+
+				<?php //if ($paged_json[$i]['template'] != 'pageModel-linkToDocument.php'){ ?>
+	            		
+            		<div class="row">
+						<div class="col-xs-12">
+		    
+							<a href="<?= $link ?>" target="_blank">
+
+								<?= $link_text ?>
+							
+							</a>
+		            		
+		            	</div>
+					</div>
+					<hr>
+				
+				<?php //} ?>
+		        
+			<?php } ?>
+		
+		<?php }else{ ?>
+				
+			<div class="row">
+				<div class="col-md-12">
+					
+					<?= lang('no_items_found_for_term') ?><strong><?= $query; ?></strong>.
+					
+				</div>
+			</div>
+
+		<?php } ?>
+
+	</div>
+
+	<!--
+	<div>
+		<nav aria-label="Page navigation example">
+			<ul class="pagination">
+				<?//= $this->pagination->create_links();?>
+			</ul>
+		</nav>
+	</div>
+	-->
+
+	<div class="container">
+		<div class="row">
+			<div class="col-md-12">
+				<nav aria-label="...">
+				  
+				    <?= $this->pagination->create_links();?>
+				  
+				</nav>
+			</div>	
+		</div>		
+	</div>
+
+	
+</section>
+
+<!-- footer -->
+<?php $this->load->view('partials/footer'); ?>
+<!-- ./footer -->

--- a/application/views/partials/internal-search-box.php
+++ b/application/views/partials/internal-search-box.php
@@ -1,0 +1,21 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+// Load helper form
+$this->load->helper('form');
+?>
+
+<?php echo form_open('home/search', 'id="internal-search-form" method="get"'); ?>
+<div class="row">
+    <div class="col-xs-12 col-sm-4 col-sm-offset-8">
+        <div class="internal-search-box">
+            <div class="input-group">
+                <input type="text" name="q" id="q" class="form-control" placeholder="<?= lang('internal_search_placeholder') ?>" value='<?php if (!empty($query)) echo $query; ?>'>
+                <div class="input-group-btn">
+                    <input type="submit" class="btn btn-primary" id="btn-internal-search" value="<?= lang('search_btn') ?>" alt="<?= lang('search_btn') ?>" title="<?= lang('search_btn') ?>">
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<?php echo form_close();?>

--- a/static/sass/_bootstrap.scss
+++ b/static/sass/_bootstrap.scss
@@ -30,7 +30,7 @@
  @import "bootstrap/navs";
  //@import "bootstrap/navbar";
  @import "bootstrap/breadcrumbs";
- //@import "bootstrap/pagination";
+ @import "bootstrap/pagination";
  @import "bootstrap/pager";
  //@import "bootstrap/labels";
  //@import "bootstrap/badges";

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -12,6 +12,10 @@ body{
 	font-family: 'Roboto', sans-serif;
 }
 
+a{
+	word-wrap: break-word;
+}
+
 .alert-notification{
 
 	[class^=col-]:first-child{
@@ -2498,3 +2502,6 @@ section{
 	padding: 0 10px 17px;
 }
   
+.internal-search-box{
+	margin: 0 0 15px;
+}


### PR DESCRIPTION
#### O que esse PR faz?
Cria uma busca interna nas páginas dos conteúdos "Sobre o Scielo".

#### Onde a revisão poderia começar?
Acesse "Sobre o SciELO" no canto superior direito.
Em todas as páginas internas neste local deve estar visível a busca.

#### Como este poderia ser testado manualmente?
Siga os passos anteriores.

#### Algum cenário de contexto que queira dar?
É importante limpar o cache do navegador ao testar.

### Screenshots
<img width="1217" alt="Screen Shot 2019-12-16 at 4 08 51 PM" src="https://user-images.githubusercontent.com/22373640/70935178-6000e300-201e-11ea-8171-5a83584741aa.png">


#### Quais são tickets relevantes?
#139 

### Referências
https://calderaforms.com/doc/searchwp-api-queries/
https://codeigniter.com/user_guide/libraries/pagination.html
https://searchwp.com/docs/kb/post-parent-attribution/

