### PR TITLE
correções: título da página de busca e abertura em nova aba

### DIFF
--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -1252,7 +1252,6 @@ class Home extends CI_Controller
         // If page number is posted, assign it in the query. $ this-> uri-> segment (3) represents page number
         if($this->uri->segment(3)){
         	$page_num = $this->uri->segment(3);
-        	$json_url = $json_url."&page=".$page_num;
         	$paged_json_url = $paged_json_url."&page=".$page_num;
         }
         
@@ -1319,9 +1318,13 @@ class Home extends CI_Controller
 		$config['num_tag_open'] = '<li>';
 		$config['num_tag_close'] = '</li>';
 
+
+		// set page title
+		$pageMetadata = array('acf' => array('pageTitle' => ucfirst(lang('search_btn')) . ' | SciELO.org'));
+		$this->PageMetadata->initialize($pageMetadata);
+
 		$this->pagination->initialize($config);
-		$this->load->view("/pages/search_results", $data);
-	
+		$this->load->view("/pages/search_results", $data);	
     }
 
 	/**

--- a/application/views/pages/search_results.php
+++ b/application/views/pages/search_results.php
@@ -94,9 +94,24 @@ defined('BASEPATH') or exit('No direct script access allowed');
 					}
 				?>
 
-				<?php //if ($paged_json[$i]['template'] != 'pageModel-linkToDocument.php'){ ?>
+				<?php if ($paged_json[$i]['template'] != 'pageModel-linkToDocument.php'){ ?>
 	            		
             		<div class="row">
+						<div class="col-xs-12">
+		    
+							<a href="<?= $link ?>">
+
+								<?= $link_text ?>
+							
+							</a>
+		            		
+		            	</div>
+					</div>
+					<hr>
+				
+				<?php }else{ ?>
+					
+					<div class="row">
 						<div class="col-xs-12">
 		    
 							<a href="<?= $link ?>" target="_blank">
@@ -109,7 +124,7 @@ defined('BASEPATH') or exit('No direct script access allowed');
 					</div>
 					<hr>
 				
-				<?php //} ?>
+				<?php } ?>
 		        
 			<?php } ?>
 		


### PR DESCRIPTION
#### O que esse PR faz?
Foram feitas as seguintes correções:
- alterado o título da página de busca para um título amigável
- apenas arquivos pdf's devem abrir em nova aba. Os links para páginas internas devem abrir na mesma aba.
- removida concatenação de string de paginação que estava sendo feita em duplicidade.

#### Onde a revisão poderia começar?
Navegue pelo sistema, vá até a página "Sobre SciELO" e efetue uma busca. Veja que o título da página de resultado de busca agora exibe um texto amigável, respeitando os idiomas.
Verifique também que os links que apontam para um arquivo do tipo pdf, deve abrir em uma nova aba. Os demais devem abrir na mesma.

#### Como este poderia ser testado manualmente?
Siga os passos já citados.

#### Algum cenário de contexto que queira dar?
-

### Screenshots
<img width="1040" alt="Screen Shot 2020-01-13 at 2 34 00 PM" src="https://user-images.githubusercontent.com/22373640/72278005-d12db900-3611-11ea-93ce-23a7ef74f170.png">


#### Quais são tickets relevantes?
#139 

### Referências
-


