### PR TITLE
Ordena as coleções e periódicos utilizando as regras do idioma corrente

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ FROM ubuntu:18.04
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install apache2 \
       libapache2-mod-php php-gd php-curl php-memcached curl python-setuptools \
-	  python-pip php-sqlite3 php-xml  php-mbstring php-cli cron && \
+	  python-pip php-sqlite3 php-xml  php-mbstring php-cli cron \
+	  language-pack-pt language-pack-en-base language-pack-es \
+	  libicu-dev php-intl && \
 	rm -rf /var/lib/apt/lists/* && \
 	pip install supervisor
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -3,7 +3,9 @@ FROM ubuntu:18.04
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install apache2 \
       libapache2-mod-php php-gd php-curl php-memcached curl python-setuptools \
-	  python-pip php-sqlite3 php-xml  php-mbstring php-cli && \
+	  python-pip php-sqlite3 php-xml  php-mbstring php-cli \
+	  language-pack-pt language-pack-en-base language-pack-es \
+	  libicu-dev php-intl && \
 	rm -rf /var/lib/apt/lists/* && \
 	pip install supervisor
 

--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -45,6 +45,7 @@ class Home extends CI_Controller
 		$this->load_about_link(); // The about link is the same in any page, so I load it here in the constructor.			
 		$this->load_openaccessdeclaration_link(); // The open access link in footer section, so I load it here in the constructor.			
 		$this->load_footer(); // The footer is the same in any page, so I load it here in the constructor.	
+		$this->currentLocale = setlocale(LC_ALL, 0); // it returns the current locale, e.g: pt_BR.UTF8
 	}
 
 	/**
@@ -207,7 +208,7 @@ class Home extends CI_Controller
 			return;
 		}
 
-		$journals = $this->Journals->list_all_journals($limit, $offset, $params['status'], $params['matching'], $params['search'], $params['letter']);
+		$journals = $this->Journals->list_all_journals($limit, $offset, $params['status'], $params['matching'], $params['search'], $params['letter'], $this->currentLocale);
 		$total_journals = $this->Journals->total_journals($params['status'], $params['matching'], $params['search'], $params['letter']);
 
 		$journals_links = $this->get_journals_links();

--- a/application/models/Journals.php
+++ b/application/models/Journals.php
@@ -86,7 +86,7 @@ class Journals extends CI_Model
      * @param   string $letter
      * @return	array
      */
-    public function list_all_journals($limit, $offset, $status = false, $matching = false, $search = false, $letter = false)
+    public function list_all_journals($limit, $offset, $status = false, $matching = false, $search = false, $letter = false, $locale = 'root')
     {
 
         $this->db->from($this->journals_table);
@@ -95,7 +95,7 @@ class Journals extends CI_Model
 
         $this->db->limit($limit, $offset);
         $this->db->group_by('title_search');
-        $this->db->order_by('title_search', 'ASC');
+        $this->db->order_by("locale('title', '$locale')");
 
         return $this->get_results_obj();
     }

--- a/application/models/Journals.php
+++ b/application/models/Journals.php
@@ -30,6 +30,19 @@ class Journals extends CI_Model
     public function __construct()
     {
         parent::__construct();
+
+        $this->db->conn_id->createFunction(
+            'locale',
+            function ($data, $locale = 'root') {
+                static $collators = array();
+
+                if (isset($collators[$locale]) !== true) {
+                    $collators[$locale] = new \Collator($locale);
+                }
+
+                return $collators[$locale]->getSortKey($data);
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request faz com que a aplicação passe a utilizar as configurações de idioma para ordenar palavras quando requerido.

#### Onde a revisão poderia começar?

Recomendo fortemente que a revisão seja feita via commits que tendem a explicar o que foi feito.

#### Como este poderia ser testado manualmente?

Para testar este pr, deve-se:
- Execute a aplicação;
- Navegue pelas páginas alvo das modificações;
- Observe a ordenação diferente da atual em scielo.org;

#### Algum cenário de contexto que queira dar?

Um exemplo de ordenação utilizando as configurações de locale pode ser simulado com o código abaixo:

```php
<?php

$locale = 'pt_BR.UTF8';
$currentLocale = setlocale(LC_ALL, $locale);
$array  = array('água', 'argentina', 'áfrica', 'aerólito');
$collator = new \Collator(null);

echo "Sem ordenação" . PHP_EOL;
foreach($array as $key => $word) {
    echo $key . " - " . $word . PHP_EOL;
}
$collator->sort($array, SORT_LOCALE_STRING);

echo "\nCom ordenação" . PHP_EOL;
foreach($array as $key => $word) {
    echo $key . " - " . $word . PHP_EOL;
}

// Sem ordenação
// 0 - água
// 1 - argentina
// 2 - áfrica
// 3 - aerólito

// Com ordenação
// 0 - aerólito
// 1 - áfrica
// 2 - água
// 3 - argentina

?>
```

### Screenshots
N/A

#### Quais são tickets relevantes?
#154

### Referências

- https://sqlite.org/datatype3.html
- https://www.php.net/manual/en/function.ksort.php
- http://www.unicode.org/reports/tr10/
- https://www.php.net/manual/en/collator.construct.php


