### PR TITLE
adicionado um div para agrupar os itens

### DIFF
--- a/application/views/partials/collections.php
+++ b/application/views/partials/collections.php
@@ -44,7 +44,7 @@ $lang_index = isset($language) ? $language : SCIELO_EN_LANG;
                 </a>
             </dd>
             <?php endforeach; ?>
-
+        <div>
             <?php 
             // Servidores e repositórios
             $counter = 0;
@@ -59,7 +59,7 @@ $lang_index = isset($language) ? $language : SCIELO_EN_LANG;
                     </a>
                 </dd>
             <?php endforeach; ?>
-
+        </div>
             <?php 
             // Livros
             $counter = 0;

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -337,6 +337,10 @@ section{
 		column-count: 1;
 		column-gap: 0;
 
+		div{
+			display: inline-block;
+		}
+
 		@media (orientation: landscape) {
 
 			@media (min-width: 485px) and (max-width: 850px) {


### PR DESCRIPTION

#### O que esse PR faz?
Resolve o problema de quebra entre os elementos da categoria servidores e repositórios.

#### Onde a revisão poderia começar?
Verifique a adição do elemento div no arquivo collections.php e de sua propriedade display:inline-block no arquivo style.less

#### Como este poderia ser testado manualmente?
Acesse a home do sistema e verifique que a quebra dos itens citados não ocorre mais.

#### Algum cenário de contexto que queira dar?
Nenhum. Apenas rode o sistema após regerar os arquivos .css e abra a Home do sistema. Será possível verificar os itens sendo exibidos um abaixo do outro na categoria servidores e repositórios.

### Screenshots
![Screen Shot 2021-03-19 at 3 02 16 PM](https://user-images.githubusercontent.com/22373640/111839325-647b1200-88d9-11eb-99f9-d176c4f1a5fc.png)


#### Quais são tickets relevantes?
#159 

### Referências
-


